### PR TITLE
bug activeadmin datetimepicker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,4 +13,7 @@ gemspec
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 
+
 gem 'inherited_resources', github: 'activeadmin/inherited_resources'
+gem 'rails', github: 'rails/rails', ref: '3cffae5953021966204854fa73bef2f9cd366e9b' # uso esta versión por un bug ya que en los includes y asociaciones las establece como readonly
+gem 'activeadmin', github: 'activeadmin', branch: :master

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,24 @@
 GIT
+  remote: git://github.com/activeadmin/activeadmin.git
+  revision: a932d56b156eaf64beb86cb45f8f801b7933c42e
+  branch: master
+  specs:
+    activeadmin (1.0.0.pre4)
+      arbre (~> 1.0, >= 1.0.2)
+      bourbon
+      coffee-rails
+      formtastic (~> 3.1)
+      formtastic_i18n
+      inherited_resources (~> 1.6)
+      jquery-rails
+      jquery-ui-rails
+      kaminari (~> 0.15)
+      railties (>= 3.2, < 5.1)
+      ransack (~> 1.3)
+      sass-rails
+      sprockets (< 4.1)
+
+GIT
   remote: git://github.com/activeadmin/inherited_resources.git
   revision: 4434f0ae72f790cf371728838c927c338100555d
   specs:
@@ -8,14 +28,10 @@ GIT
       railties (>= 3.2, < 5.1)
       responders
 
-PATH
-  remote: .
-  specs:
-    activeadmin_custom_layout (0.1.0)
-      activeadmin (>= 1.0.0.pre4)
-
-GEM
-  remote: https://rubygems.org/
+GIT
+  remote: git://github.com/rails/rails.git
+  revision: 3cffae5953021966204854fa73bef2f9cd366e9b
+  ref: 3cffae5953021966204854fa73bef2f9cd366e9b
   specs:
     actioncable (5.0.0.1)
       actionpack (= 5.0.0.1)
@@ -40,20 +56,6 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    activeadmin (1.0.0.pre4)
-      arbre (~> 1.0, >= 1.0.2)
-      bourbon
-      coffee-rails
-      formtastic (~> 3.1)
-      formtastic_i18n
-      inherited_resources (~> 1.6)
-      jquery-rails
-      jquery-ui-rails
-      kaminari (~> 0.15)
-      rails (>= 3.2, < 5.1)
-      ransack (~> 1.3)
-      sass-rails
-      sprockets (< 4)
     activejob (5.0.0.1)
       activesupport (= 5.0.0.1)
       globalid (>= 0.3.6)
@@ -68,12 +70,39 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    rails (5.0.0.1)
+      actioncable (= 5.0.0.1)
+      actionmailer (= 5.0.0.1)
+      actionpack (= 5.0.0.1)
+      actionview (= 5.0.0.1)
+      activejob (= 5.0.0.1)
+      activemodel (= 5.0.0.1)
+      activerecord (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      bundler (>= 1.3.0, < 2.0)
+      railties (= 5.0.0.1)
+      sprockets-rails (>= 2.0.0)
+    railties (5.0.0.1)
+      actionpack (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+
+PATH
+  remote: .
+  specs:
+    activeadmin_custom_layout (0.1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
     arbre (1.1.1)
       activesupport (>= 3.0.0)
-    arel (7.1.2)
+    arel (7.1.4)
     ast (2.3.0)
     awesome_print (1.7.0)
     bcrypt (3.1.11)
@@ -89,7 +118,7 @@ GEM
     coffee-script (2.4.1)
       coffee-script-source
       execjs
-    coffee-script-source (1.10.0)
+    coffee-script-source (1.11.1)
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
     devise (4.2.0)
@@ -114,7 +143,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (5.0.5)
+    jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
@@ -131,7 +160,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.10.0)
     nio4r (1.2.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -153,29 +182,11 @@ GEM
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (5.0.0.1)
-      actioncable (= 5.0.0.1)
-      actionmailer (= 5.0.0.1)
-      actionpack (= 5.0.0.1)
-      actionview (= 5.0.0.1)
-      activejob (= 5.0.0.1)
-      activemodel (= 5.0.0.1)
-      activerecord (= 5.0.0.1)
-      activesupport (= 5.0.0.1)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 5.0.0.1)
-      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    railties (5.0.0.1)
-      actionpack (= 5.0.0.1)
-      activesupport (= 5.0.0.1)
-      method_source
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
     rake (11.2.2)
     ransack (1.8.2)
@@ -237,6 +248,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activeadmin!
   activeadmin_custom_layout!
   annotate
   awesome_print
@@ -245,6 +257,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   pry (~> 0.10.4)
   pry-byebug (~> 3.4.0)
+  rails!
   rubocop
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/activeadmin_custom_layout.gemspec
+++ b/activeadmin_custom_layout.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency "activeadmin", ">= 1.0.0.pre4"
+#  s.add_dependency "activeadmin", ">= 1.0.0.pre4"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "devise", "~> 4.2.0"

--- a/lib/activeadmin_custom_layout/version.rb
+++ b/lib/activeadmin_custom_layout/version.rb
@@ -1,3 +1,3 @@
 module ActiveadminCustomLayout
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end


### PR DESCRIPTION
Se cambian las versiones de rails y activeadmin porque habia un problema con libreria datetimepicker